### PR TITLE
Dockerfile with signature check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-# Use the appropriate base image for your container
-FROM debian:bullseye-slim
+ARG DEBIAN_VERSION=12
 
-# Install necessary packages and VeraCrypt
+FROM debian:$DEBIAN_VERSION-slim
+
+# NOTE: ARGs need to be redefined after FROM
+ARG DEBIAN_VERSION
+ARG VERACRYPT_VERSION=1.26.14
+
+ARG VERACRYPT_URL="https://launchpad.net/veracrypt/trunk/${VERACRYPT_VERSION}/+download/veracrypt-${VERACRYPT_VERSION}-Debian-${DEBIAN_VERSION}-amd64.deb"
+ARG VERACRYPT_SIG="${VERACRYPT_URL}.sig"
+# See https://veracrypt.eu/en/Digital%20Signatures.html
+ENV VERACRYPT_FINGERPRINT=5069A233D55A0EEB174A5FC3821ACD02680D16DE
+
+# Install necessary packages and VeraCrypt, after checking its signature.
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
-    wget -q https://launchpad.net/veracrypt/trunk/1.24-update7/+download/veracrypt-1.24-Update7-Debian-11-amd64.deb -O veracrypt.deb && \
+    wget -q ${VERACRYPT_URL} -O veracrypt.deb && \
+    wget -q ${VERACRYPT_SIG} -O veracrypt.sig && \
     wget -q https://www.idrix.fr/VeraCrypt/VeraCrypt_PGP_public_key.asc -O veracrypt.asc && \
+    ( gpg --import --import-options show-only veracrypt.asc | grep ${VERACRYPT_FINGERPRINT} ) && \
     gpg --import veracrypt.asc && \
-    gpg --verify veracrypt.deb && \
-    dpkg -i veracrypt.deb || true && \
-    apt-get -f install -y && \
-    rm -f veracrypt.deb veracrypt.asc && \
+    gpg --verify veracrypt.sig veracrypt.deb && \
+    apt-get install ./veracrypt.deb -y --no-install-recommends && \
+    rm -f veracrypt.deb veracrypt.sig veracrypt.asc && \
     apt-get autoremove --purge -y wget gnupg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It allows to define DEBIAN VERSION (11 or 12), as well as VERACRYPT_VERSION.

It downloads the corresponding deb, along with its signature. It checks the veracrypt source FINGERPRINT against a known source, and it checks the deb signature, before installing it.

If anything goes wrong during the build process, the whole process fails.